### PR TITLE
Implement extras message callbacks

### DIFF
--- a/codegen/src/extras.rs
+++ b/codegen/src/extras.rs
@@ -181,7 +181,7 @@ impl ExtrasGen {
                 quote_spanned! {span=>
                     unsafe extern "C" fn abstract_extras_chat_message(info: *const ::arcdps::extras::message::RawChatMessageInfo) {
                         let safe = (#safe) as ExtrasChatMessageCallback;
-                        safe(info.into())
+                        safe(&(*info).into())
                     }
                 }
             },

--- a/codegen/src/extras.rs
+++ b/codegen/src/extras.rs
@@ -181,7 +181,7 @@ impl ExtrasGen {
                 quote_spanned! {span=>
                     unsafe extern "C" fn abstract_extras_chat_message(info: *const ::arcdps::extras::message::RawChatMessageInfo) {
                         let safe = (#safe) as ExtrasChatMessageCallback;
-                        safe(&(*info).into())
+                        safe(&::arcdps::extras::message::ChatMessageInfo::from(&*info))
                     }
                 }
             },

--- a/codegen/src/extras.rs
+++ b/codegen/src/extras.rs
@@ -38,8 +38,7 @@ impl ExtrasGen {
             unwrap(self.build_extras_language_changed());
         let (keybind_changed_func, keybind_changed_value) =
             unwrap(self.build_extras_keybind_changed());
-        let (chat_message_func, chat_message_value) =
-            unwrap(self.build_extras_chat_message());
+        let (chat_message_func, chat_message_value) = unwrap(self.build_extras_chat_message());
         let init_func = self.build_extras_init(
             name,
             squad_update_value,

--- a/codegen/src/extras.rs
+++ b/codegen/src/extras.rs
@@ -179,7 +179,7 @@ impl ExtrasGen {
             quote! { abstract_extras_chat_message },
             |safe, span| {
                 quote_spanned! {span=>
-                    unsafe extern "C" fn abstract_extras_chat_message(info: ::arcdps::extras::message::RawChatMessageInfo) {
+                    unsafe extern "C" fn abstract_extras_chat_message(info: *const ::arcdps::extras::message::RawChatMessageInfo) {
                         let safe = (#safe) as ExtrasChatMessageCallback;
                         safe(info.into())
                     }

--- a/codegen/src/parse.rs
+++ b/codegen/src/parse.rs
@@ -119,7 +119,8 @@ impl Parse for ArcDpsGen {
                                 extras_init,
                                 extras_squad_update,
                                 extras_language_changed,
-                                extras_keybind_changed
+                                extras_keybind_changed,
+                                extras_chat_message
                             }
                         )
                     }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT/Apache-2.0"
 [dependencies]
 arcdps-codegen = { path = "../codegen" }
 arcdps-imgui = { version = "0.8", features = ["tables-api"] }
-chrono = { version = "0.4.19", features = ["serde"] }
+chrono = "0.4.19"
 log = { version = "0.4", features = ["std"], optional = true }
 num_enum = "0.5"
 serde = { version = "1.0", features = ["derive"], optional = true }
@@ -30,3 +30,4 @@ features = [
 [features]
 default = []
 extras = ["arcdps-codegen/extras"]
+serde = ["serde", "chrono/serde"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -12,6 +12,7 @@ license = "MIT/Apache-2.0"
 [dependencies]
 arcdps-codegen = { path = "../codegen" }
 arcdps-imgui = { version = "0.8", features = ["tables-api"] }
+chrono = { version = "0.4.19", features = ["serde"] }
 log = { version = "0.4", features = ["std"], optional = true }
 num_enum = "0.5"
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -30,4 +30,4 @@ features = [
 [features]
 default = []
 extras = ["arcdps-codegen/extras"]
-serde = ["serde", "chrono/serde"]
+serde = ["dep:serde", "chrono/serde"]

--- a/core/src/extras/callbacks.rs
+++ b/core/src/extras/callbacks.rs
@@ -1,6 +1,6 @@
 use super::{
     keybinds::{KeybindChange, RawKeybindChange},
-    message::{ChatMessageInfoOwned, RawChatMessageInfo},
+    message::{ChatMessageInfo, RawChatMessageInfo},
     ExtrasAddonInfo, ExtrasSubscriberInfo, RawExtrasAddonInfo, RawUserInfo, UserInfoIter,
 };
 use crate::api::Language;
@@ -24,4 +24,4 @@ pub type ExtrasKeybindChangedCallback = fn(changed: KeybindChange);
 
 pub type RawExtrasChatMessageCallback =
     unsafe extern "C" fn(chat_message: *const RawChatMessageInfo);
-pub type ExtrasChatMessageCallback = fn(chat_message_info: ChatMessageInfoOwned);
+pub type ExtrasChatMessageCallback = fn(chat_message_info: ChatMessageInfo);

--- a/core/src/extras/callbacks.rs
+++ b/core/src/extras/callbacks.rs
@@ -1,6 +1,6 @@
 use super::{
     keybinds::{KeybindChange, RawKeybindChange},
-    message::ChatMessageInfo,
+    message::{ChatMessageInfoOwned, RawChatMessageInfo},
     ExtrasAddonInfo, ExtrasSubscriberInfo, RawExtrasAddonInfo, RawUserInfo, UserInfoIter,
 };
 use crate::api::Language;
@@ -22,4 +22,5 @@ pub type ExtrasLanguageChangedCallback = fn(new_language: Language);
 pub type RawExtrasKeybindChangedCallback = unsafe extern "C" fn(changed: RawKeybindChange);
 pub type ExtrasKeybindChangedCallback = fn(changed: KeybindChange);
 
-pub type RawExtrasChatMessageCallback = unsafe extern "C" fn(chat_message: *const ChatMessageInfo);
+pub type RawExtrasChatMessageCallback = unsafe extern "C" fn(chat_message: *const RawChatMessageInfo);
+pub type ExtrasChatMessageCallback = fn(chat_message_info: ChatMessageInfoOwned);

--- a/core/src/extras/callbacks.rs
+++ b/core/src/extras/callbacks.rs
@@ -22,5 +22,6 @@ pub type ExtrasLanguageChangedCallback = fn(new_language: Language);
 pub type RawExtrasKeybindChangedCallback = unsafe extern "C" fn(changed: RawKeybindChange);
 pub type ExtrasKeybindChangedCallback = fn(changed: KeybindChange);
 
-pub type RawExtrasChatMessageCallback = unsafe extern "C" fn(chat_message: *const RawChatMessageInfo);
+pub type RawExtrasChatMessageCallback =
+    unsafe extern "C" fn(chat_message: *const RawChatMessageInfo);
 pub type ExtrasChatMessageCallback = fn(chat_message_info: ChatMessageInfoOwned);

--- a/core/src/extras/callbacks.rs
+++ b/core/src/extras/callbacks.rs
@@ -24,4 +24,4 @@ pub type ExtrasKeybindChangedCallback = fn(changed: KeybindChange);
 
 pub type RawExtrasChatMessageCallback =
     unsafe extern "C" fn(chat_message: *const RawChatMessageInfo);
-pub type ExtrasChatMessageCallback = fn(chat_message_info: ChatMessageInfo);
+pub type ExtrasChatMessageCallback = fn(chat_message_info: &ChatMessageInfo);

--- a/core/src/extras/message.rs
+++ b/core/src/extras/message.rs
@@ -19,6 +19,31 @@ pub struct ChatMessageInfoOwned {
     pub text: String,
 }
 
+impl From<RawChatMessageInfo> for ChatMessageInfoOwned {
+    fn from(raw: RawChatMessageInfo) -> Self {
+        let timestamp = unsafe { get_str_from_ptr_and_len(msg.timestamp, msg.timestamp_length) };
+        let timestamp = chrono::DateTime::parse_from_rfc3339(timestamp).unwrap();
+
+        let account_name =
+            unsafe { get_str_from_ptr_and_len(msg.account_name, msg.account_name_length) };
+        let character_name =
+            unsafe { get_str_from_ptr_and_len(msg.character_name, msg.character_name_length) };
+        let text = unsafe { get_str_from_ptr_and_len(msg.text, msg.text_length) };
+        let is_broadcast = (msg.is_broadcast & 0x01) != 0;
+
+        Self {
+            channel_id: msg.channel_id,
+            channel_type: msg.channel_type,
+            subgroup: msg.subgroup,
+            is_broadcast,
+            timestamp,
+            account_name: account_name.trim_start_matches(':'),
+            character_name,
+            text,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct ChatMessageInfo<'a> {
     pub channel_id: u32,
@@ -60,4 +85,11 @@ pub enum ChannelType {
     Squad = 1,
     Reserved = 2,
     Invalid = 3,
+}
+
+/// Converts a pointer and length into a &str with a lifetime. The pointer must not be null
+#[inline(always)]
+unsafe fn get_str_from_ptr_and_len(src: *const u8, len: u64) -> &'static str {
+    let buff = std::slice::from_raw_parts(src, len as usize);
+    std::str::from_utf8_unchecked(buff)
 }

--- a/core/src/extras/message.rs
+++ b/core/src/extras/message.rs
@@ -46,8 +46,8 @@ pub struct ChatMessageInfo<'a> {
     pub text: &'a str,
 }
 
-impl From<RawChatMessageInfo> for ChatMessageInfo<'_> {
-    fn from(raw: RawChatMessageInfo) -> Self {
+impl From<&RawChatMessageInfo> for ChatMessageInfo<'_> {
+    fn from(raw: &RawChatMessageInfo) -> Self {
         let timestamp = unsafe { get_str_from_ptr_and_len(raw.timestamp, raw.timestamp_length) };
         let timestamp = chrono::DateTime::parse_from_rfc3339(timestamp).unwrap();
 

--- a/core/src/extras/message.rs
+++ b/core/src/extras/message.rs
@@ -1,4 +1,4 @@
-use std::os::raw::c_char;
+use chrono::{DateTime, FixedOffset};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -12,29 +12,56 @@ pub struct ChatMessageInfoOwned {
     pub channel_id: u32,
     pub channel_type: ChannelType,
     pub subgroup: u8,
-    pub unused1: u16,
-    pub timestamp: String,
+    pub is_broadcast: bool,
+    pub timestamp: DateTime<FixedOffset>,
     pub account_name: String,
     pub character_name: String,
     pub text: String,
 }
 
-impl From<RawChatMessageInfo> for ChatMessageInfoOwned {
+impl From<ChatMessageInfo<'_>> for ChatMessageInfoOwned {
+    fn from(chat: ChatMessageInfo<'_>) -> Self {
+        Self {
+            channel_id: chat.channel_id,
+            channel_type: chat.channel_type,
+            subgroup: chat.subgroup,
+            is_broadcast: chat.is_broadcast,
+            timestamp: chat.timestamp,
+            account_name: chat.account_name.to_string(),
+            character_name: chat.character_name.to_string(),
+            text: chat.text.to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ChatMessageInfo<'a> {
+    pub channel_id: u32,
+    pub channel_type: ChannelType,
+    pub subgroup: u8,
+    pub is_broadcast: bool,
+    pub timestamp: DateTime<FixedOffset>,
+    pub account_name: &'a str,
+    pub character_name: &'a str,
+    pub text: &'a str,
+}
+
+impl From<RawChatMessageInfo> for ChatMessageInfo<'_> {
     fn from(raw: RawChatMessageInfo) -> Self {
-        let timestamp = unsafe { get_str_from_ptr_and_len(msg.timestamp, msg.timestamp_length) };
+        let timestamp = unsafe { get_str_from_ptr_and_len(raw.timestamp, raw.timestamp_length) };
         let timestamp = chrono::DateTime::parse_from_rfc3339(timestamp).unwrap();
 
         let account_name =
-            unsafe { get_str_from_ptr_and_len(msg.account_name, msg.account_name_length) };
+            unsafe { get_str_from_ptr_and_len(raw.account_name, raw.account_name_length) };
         let character_name =
-            unsafe { get_str_from_ptr_and_len(msg.character_name, msg.character_name_length) };
-        let text = unsafe { get_str_from_ptr_and_len(msg.text, msg.text_length) };
-        let is_broadcast = (msg.is_broadcast & 0x01) != 0;
+            unsafe { get_str_from_ptr_and_len(raw.character_name, raw.character_name_length) };
+        let text = unsafe { get_str_from_ptr_and_len(raw.text, raw.text_length) };
+        let is_broadcast = (raw.is_broadcast & 0x01) != 0;
 
         Self {
-            channel_id: msg.channel_id,
-            channel_type: msg.channel_type,
-            subgroup: msg.subgroup,
+            channel_id: raw.channel_id,
+            channel_type: raw.channel_type,
+            subgroup: raw.subgroup,
             is_broadcast,
             timestamp,
             account_name: account_name.trim_start_matches(':'),
@@ -45,31 +72,51 @@ impl From<RawChatMessageInfo> for ChatMessageInfoOwned {
 }
 
 #[derive(Debug, Clone)]
-pub struct ChatMessageInfo<'a> {
-    pub channel_id: u32,
-    pub channel_type: ChannelType,
-    pub subgroup: u8,
-    pub unused1: u16,
-    pub timestamp: &'a str,
-    pub account_name: &'a str,
-    pub character_name: &'a str,
-    pub text: &'a str,
-}
-
-#[derive(Debug, Clone)]
 #[repr(C)]
 pub struct RawChatMessageInfo {
+    /// A unique identifier for the channel this chat message was sent over. Can
+    /// be used to, for example, differentiate between squad messages sent to
+    /// different squads
     pub channel_id: u32,
+
+    /// Whether the message is sent in a party or a squad. Note that messages
+    /// sent to the party chat while in a squad will have the type
+    /// ChannelType::Squad
     pub channel_type: ChannelType,
+
+    /// The subgroup the message was sent to, or 0 if it was sent to the entire
+    /// squad.
     pub subgroup: u8,
-    pub unused1: u16,
-    pub timestamp: *const c_char,
+
+    /// This lowest bit of this field will be set to 1 if the message is a
+    /// broadcast, and 0 if it is not a broadcast. The upper bits of this field
+    /// may be used in a later version and MUST NOT be interpreted
+    pub is_broadcast: u8,
+
+    pub _unused1: u8,
+
+    /// Null terminated iso8601 formatted string denoting when this message was
+    /// received by the server, e.g. "2022-07-09T11:45:24.888Z". This is the
+    /// "absolute ordering" for chat messages, however the time can potentially
+    /// differ several seconds between the client and server because of latency
+    /// and clock skew. The string is only valid for the duration of the call.
+    pub timestamp: *const u8,
     pub timestamp_length: u64,
-    pub account_name: *const c_char,
+
+    /// Null terminated account name of the player that sent the message,
+    /// including leading ':'. The string is only valid for the duration of the
+    /// call.
+    pub account_name: *const u8,
     pub account_name_length: u64,
-    pub character_name: *const c_char,
+
+    /// Null terminated character name of the player that sent the message. The
+    /// string is only valid for the duration of the call.
+    pub character_name: *const u8,
     pub character_name_length: u64,
-    pub text: *const c_char,
+
+    /// Null terminated string containing the content of the message that was
+    /// sent. The string is only valid for the duration of the call.
+    pub text: *const u8,
     pub text_length: u64,
 }
 

--- a/core/src/extras/mod.rs
+++ b/core/src/extras/mod.rs
@@ -5,8 +5,8 @@
 pub mod callbacks;
 pub mod exports;
 pub mod keybinds;
+pub mod message;
 
-mod message;
 mod user;
 
 pub use keybinds::{Control, Key, KeyCode, KeybindChange, MouseCode};

--- a/core/src/extras/mod.rs
+++ b/core/src/extras/mod.rs
@@ -14,7 +14,7 @@ pub use user::*;
 
 use crate::util::str_from_cstr;
 use callbacks::{
-    RawExtrasKeybindChangedCallback, RawExtrasLanguageChangedCallback, RawExtrasSquadUpdateCallback,
+    RawExtrasKeybindChangedCallback, RawExtrasLanguageChangedCallback, RawExtrasSquadUpdateCallback, RawExtrasChatMessageCallback,
 };
 use std::os::raw::c_char;
 use windows::Win32::Foundation::HINSTANCE;
@@ -138,6 +138,9 @@ pub struct ExtrasSubscriberInfo {
     /// After initialization this is called for every current keybind that exists.
     /// If you want to get a single keybind, at any time you want, call the exported function.
     pub keybind_changed_callback: Option<RawExtrasKeybindChangedCallback>,
+
+    /// Called whenever a chat message is sent in your party/squad
+    pub chat_message_callback: Option<RawChatMessageCallbackSignature>,
 }
 
 impl ExtrasSubscriberInfo {
@@ -150,11 +153,13 @@ impl ExtrasSubscriberInfo {
         squad_update: Option<RawExtrasSquadUpdateCallback>,
         language_changed: Option<RawExtrasLanguageChangedCallback>,
         keybind_changed: Option<RawExtrasKeybindChangedCallback>,
+        chat_message: Option<RawExtrasChatMessageCallback>,
     ) {
         self.header.info_version = SUB_INFO_VERSION;
         self.subscriber_name = name.as_ptr() as *const c_char;
         self.squad_update_callback = squad_update;
         self.language_changed_callback = language_changed;
         self.keybind_changed_callback = keybind_changed;
+        self.chat_message_callback = chat_message;
     }
 }

--- a/core/src/extras/mod.rs
+++ b/core/src/extras/mod.rs
@@ -26,7 +26,7 @@ use serde::{Deserialize, Serialize};
 const API_VERSION: u32 = 2;
 
 /// Supported [`ExtrasSubscriberInfo`] version.
-const SUB_INFO_VERSION: u32 = 1;
+const SUB_INFO_VERSION: u32 = 2;
 
 /// Helper to check compatibility.
 fn check_compat(api_version: u32, sub_info_version: u32) -> bool {

--- a/core/src/extras/mod.rs
+++ b/core/src/extras/mod.rs
@@ -14,7 +14,8 @@ pub use user::*;
 
 use crate::util::str_from_cstr;
 use callbacks::{
-    RawExtrasKeybindChangedCallback, RawExtrasLanguageChangedCallback, RawExtrasSquadUpdateCallback, RawExtrasChatMessageCallback,
+    RawExtrasChatMessageCallback, RawExtrasKeybindChangedCallback,
+    RawExtrasLanguageChangedCallback, RawExtrasSquadUpdateCallback,
 };
 use std::os::raw::c_char;
 use windows::Win32::Foundation::HINSTANCE;
@@ -140,7 +141,7 @@ pub struct ExtrasSubscriberInfo {
     pub keybind_changed_callback: Option<RawExtrasKeybindChangedCallback>,
 
     /// Called whenever a chat message is sent in your party/squad
-    pub chat_message_callback: Option<RawChatMessageCallbackSignature>,
+    pub chat_message_callback: Option<RawExtrasChatMessageCallback>,
 }
 
 impl ExtrasSubscriberInfo {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -205,6 +205,12 @@ pub struct SupportedFields {
     #[cfg(feature = "extras")]
     pub raw_extras_keybind_changed: Option<RawExtrasKeybindChangedCallback>,
 
+    /// Raw extras chat message callback.
+    ///
+    /// *Requires the `"extras"` feature.*
+    #[cfg(feature = "extras")]
+    pub raw_extras_chat_message: Option<RawExtrasChatMessageCallback>,
+
     /// Initialization callback for [Unofficial Extras](https://github.com/Krappa322/arcdps_unofficial_extras_releases).
     ///
     /// Can be called before or after ArcDPS [`init`](Self::init).
@@ -245,6 +251,14 @@ pub struct SupportedFields {
     /// *Requires the `"extras"` feature.*
     #[cfg(feature = "extras")]
     pub extras_keybind_changed: Option<ExtrasKeybindChangedCallback>,
+
+    /// Chat message callback for [Unofficial Extras](https://github.com/Krappa322/arcdps_unofficial_extras_releases).
+    ///
+    /// Called whenever a chat message is sent in your party/squad
+    ///
+    /// *Requires the `"extras"` feature.*
+    #[cfg(feature = "extras")]
+    pub extras_chat_messaage: Option<ExtrasChatMessageCallback>,
 }
 
 /// Exports for usage in macros.

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -258,7 +258,7 @@ pub struct SupportedFields {
     ///
     /// *Requires the `"extras"` feature.*
     #[cfg(feature = "extras")]
-    pub extras_chat_messaage: Option<ExtrasChatMessageCallback>,
+    pub extras_chat_message: Option<ExtrasChatMessageCallback>,
 }
 
 /// Exports for usage in macros.


### PR DESCRIPTION
I will preface the PR that I'm not very familiar with Rust, so code might be questionable in places (and the commits should probably be squashed before merging).

Adapts https://github.com/Krappa322/arcdps_bindings/commit/c71ef3074e59e508e5af407a0184bcf0ea40cb29 for this fork. The minimum supported info version is also bumped to 2 (matching https://github.com/Krappa322/arcdps_unofficial_extras_releases/commit/6f03e537081396f12ab53867280a842f4c3a51a3#diff-34353b9ec976c5bbcb14db5a487b00a958cb9cecb34ed019f6a18bd60bfcb641R167), which means only unofficial_extras v1.5 and above (https://github.com/Krappa322/arcdps_unofficial_extras_releases/releases/tag/v1.5.rc1) will be supported.

Tested with a plugin over at https://github.com/cheahjs/arcdps-chat-log.