### PR TITLE
implement File logging #6

### DIFF
--- a/arcdps/src/lib.rs
+++ b/arcdps/src/lib.rs
@@ -298,7 +298,7 @@ pub mod __macro {
     use prelude::*;
 
     #[cfg(feature = "log")]
-    use crate::log::WindowLogger;
+    use crate::log::ArcdpsLogger;
 
     /// Internally used function to initialize with information received from Arc.
     #[inline]
@@ -323,7 +323,7 @@ pub mod __macro {
         // only set logger if export e8 was found
         #[cfg(feature = "log")]
         if ARC_GLOBALS.e8.is_some() {
-            let result = log::set_boxed_logger(Box::new(WindowLogger::new(name)));
+            let result = log::set_boxed_logger(Box::new(ArcdpsLogger::new(name)));
             if result.is_ok() {
                 log::set_max_level(log::LevelFilter::Trace);
             }

--- a/arcdps/src/log.rs
+++ b/arcdps/src/log.rs
@@ -2,27 +2,46 @@
 //!
 //! *Requires the `"log"` feature.*
 
-use crate::exports::log_to_window;
+use crate::exports::{log_to_file, log_to_window};
 use log::{Log, Metadata, Record};
 
-/// A logger logging to ArcDPS' log window.
-pub struct WindowLogger {
+pub(crate) struct ArcdpsLogger {
     name: &'static str,
 }
 
-impl WindowLogger {
-    /// Creates a new window logger.
-    pub const fn new(name: &'static str) -> Self {
+impl ArcdpsLogger {
+    pub(crate) fn new(name: &'static str) -> Self {
         Self { name }
     }
 }
 
-impl Log for WindowLogger {
+impl Log for ArcdpsLogger {
     fn enabled(&self, _metadata: &Metadata) -> bool {
         true
     }
 
     fn log(&self, record: &Record) {
+        FileLogger::log(&FileLogger { name: self.name }, record);
+        WindowLogger::log(&WindowLogger { name: self.name }, record);
+    }
+
+    fn flush(&self) {}
+}
+
+/// A logger logging to ArcDPS' log window.
+struct WindowLogger {
+    name: &'static str,
+}
+
+impl Log for WindowLogger {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        metadata.target() != "file" // by default log to window
+    }
+
+    fn log(&self, record: &Record) {
+        if !self.enabled(record.metadata()) {
+            return;
+        }
         // TODO: coloring
         let message = format!(
             "{} {}: {}",
@@ -31,6 +50,32 @@ impl Log for WindowLogger {
             record.args()
         );
         let _ = log_to_window(message);
+    }
+
+    fn flush(&self) {}
+}
+
+/// A logger logging to ArcDPS' log file.
+struct FileLogger {
+    name: &'static str,
+}
+
+impl Log for FileLogger {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        ["file", "both"].contains(&metadata.target())
+    }
+
+    fn log(&self, record: &Record) {
+        if !self.enabled(record.metadata()) {
+            return;
+        }
+        let message = format!(
+            "{} {}: {}",
+            self.name,
+            record.level().to_string().to_lowercase(),
+            record.args()
+        );
+        let _ = log_to_file(message);
     }
 
     fn flush(&self) {}

--- a/example_plugin/src/lib.rs
+++ b/example_plugin/src/lib.rs
@@ -16,6 +16,10 @@ arcdps::export! {
 
 fn init() -> Result<(), Box<dyn Error>> {
     info!("plugin has been started");
+    // target: "window" is the same as not specifying target
+    info!(target: "window", "only window logging");
+    info!(target: "file", "only file logging");
+    info!(target: "both", "logging to file and window");
     Ok(())
 }
 


### PR DESCRIPTION
This implements Issue #6

I kept the default behavior to only log to window as this is what it used to do.

you can now specify `target: "file"` or `target: "both"` to log to file or file and window.