### PR TITLE
Report the compiled imgui version in the main export table

### DIFF
--- a/arcdps_codegen/src/export.rs
+++ b/arcdps_codegen/src/export.rs
@@ -61,7 +61,7 @@ impl ArcDpsGen {
             static __EXPORT: ::arcdps::callbacks::ArcDpsExport = ::arcdps::callbacks::ArcDpsExport {
                 size: ::std::mem::size_of::<::arcdps::callbacks::ArcDpsExport>(),
                 sig: #sig,
-                imgui_version: 18000,
+                imgui_version: ::arcdps::__macro::IMGUI_VERSION,
                 out_build: #build.as_ptr() as _,
                 out_name: #name_c.as_ptr() as _,
                 combat: #combat_value,


### PR DESCRIPTION
`d1ce764` ("Implement imgui version param") changed `EXPORT_ERROR` to report `IMGUI_VERSION`, but the real export table a few lines above still reports a hardcoded `18000`, so that is what arcdps sees for every plugin regardless of what it was built against.

This is invisible today, because `IMGUI_VERSION` is `1_80_00` — the two are equal. It stops being invisible the moment the bindings move off Dear ImGui 1.80: arcdps compares the reported number against its own and silently drops the plugin's UI callbacks on a mismatch, which since the 20260507 build (imgui 1.92.7) means every plugin loads but never draws.

I hit this porting a plugin to 1.92.7: the plugin was correctly compiled against 1.92.7 but still announced 18000, and arcdps logged

```
warning: ignoring ui callbacks for "...", imgui version mismatch: 18000 != 19270
```

The fix is to use the same constant the error struct already uses. No behaviour change on `main` (both are 18000); it just stops the number being wrong once `IMGUI_VERSION` moves.

Separately I have the actual 1.92.7 bump working, but it depends on an imgui-rs fork, so I'll open that as its own PR rather than mixing it in here.
