### PR TITLE
Build against Dear ImGui 1.92.7

### DIFF
--- a/arcdps/Cargo.toml
+++ b/arcdps/Cargo.toml
@@ -15,7 +15,7 @@ arcdps_codegen = { path = "../arcdps_codegen", optional = true }
 # Fork of imgui-rs `main` vendoring Dear ImGui 1.92.7 with arcdps's stock imconfig.
 # arcdps has linked 1.92.7 since its 20260507 build and ignores the UI callbacks of any
 # addon reporting a different IMGUI_VERSION_NUM; arcdps-imgui 0.8 is Dear ImGui 1.80.
-imgui = { path = "../../imgui-rs/imgui", features = ["tables-api"] }
+imgui = { git = "https://github.com/arnalon/imgui-rs", branch = "arcdps-1.92.7", features = ["tables-api"] }
 bitflags = { workspace = true }
 evtc = { path = "../evtc", features = ["realtime"] }
 log = { version = "0.4.17", features = ["std"], optional = true }

--- a/arcdps/Cargo.toml
+++ b/arcdps/Cargo.toml
@@ -12,7 +12,10 @@ license = "MIT"
 
 [dependencies]
 arcdps_codegen = { path = "../arcdps_codegen", optional = true }
-arcdps-imgui = { version = "0.8.0", features = ["tables-api"] }
+# Fork of imgui-rs `main` vendoring Dear ImGui 1.92.7 with arcdps's stock imconfig.
+# arcdps has linked 1.92.7 since its 20260507 build and ignores the UI callbacks of any
+# addon reporting a different IMGUI_VERSION_NUM; arcdps-imgui 0.8 is Dear ImGui 1.80.
+imgui = { path = "../../imgui-rs/imgui", features = ["tables-api"] }
 bitflags = { workspace = true }
 evtc = { path = "../evtc", features = ["realtime"] }
 log = { version = "0.4.17", features = ["std"], optional = true }

--- a/arcdps/src/globals/imgui.rs
+++ b/arcdps/src/globals/imgui.rs
@@ -2,21 +2,23 @@ use crate::{
     imgui::{self, Context, Ui},
     util::Share,
 };
-use std::{ffi::c_void, ptr, sync::OnceLock};
+use std::{ffi::c_void, mem::ManuallyDrop, ptr, sync::OnceLock};
 
-pub const IMGUI_VERSION: u32 = 1_80_00;
+/// Dear ImGui version the bindings were compiled against.
+///
+/// arcdps compares this against its own `IMGUI_VERSION_NUM` and drops the UI callbacks of any
+/// plugin that disagrees, so it has to come from the headers rather than be hardcoded.
+pub const IMGUI_VERSION: u32 = imgui::sys::IMGUI_VERSION_NUM;
 
 pub type MallocFn = unsafe extern "C" fn(size: usize, user_data: *mut c_void) -> *mut c_void;
 
 pub type FreeFn = unsafe extern "C" fn(ptr: *mut c_void, user_data: *mut c_void);
 
 /// ImGui context.
-pub static IG_CONTEXT: OnceLock<Share<Context>> = OnceLock::new();
-
-thread_local! {
-    /// ImGui UI.
-    pub static IG_UI: Ui<'static> = Ui::from_ctx(unsafe { imgui_context() });
-}
+///
+/// Owned by arcdps, hence [`ManuallyDrop`]: dropping an [`imgui::Context`] destroys the
+/// underlying context.
+pub static IG_CONTEXT: OnceLock<Share<ManuallyDrop<Context>>> = OnceLock::new();
 
 /// Initializes ImGui information.
 pub unsafe fn init_imgui(
@@ -27,7 +29,7 @@ pub unsafe fn init_imgui(
     IG_CONTEXT.get_or_init(|| unsafe {
         imgui::sys::igSetCurrentContext(ctx);
         imgui::sys::igSetAllocatorFunctions(malloc, free, ptr::null_mut());
-        Share::new(Context::current())
+        Share::new(Context::current_borrowed())
     });
 }
 
@@ -44,6 +46,6 @@ pub unsafe fn imgui_context() -> &'static Context {
 
 /// Retrieves the [`imgui::Ui`] for rendering.
 #[inline]
-pub unsafe fn with_ui<R>(body: impl FnOnce(&Ui<'static>) -> R) -> R {
-    IG_UI.with(body)
+pub unsafe fn with_ui<R>(body: impl FnOnce(&Ui) -> R) -> R {
+    body(unsafe { imgui_context() }.borrowed_frame())
 }

--- a/arcdps/src/lib.rs
+++ b/arcdps/src/lib.rs
@@ -109,7 +109,7 @@ pub use crate::globals::{
     imgui::{imgui_context, init_imgui, with_ui},
 };
 pub use crate::util::strip_account_prefix;
-pub use arcdps_imgui as imgui;
+pub use imgui;
 pub use evtc::{
     Affinity, Agent, AgentOwned, Attribute, BuffCategory, CombatResult, CustomSkill, Event,
     Language, Profession, Specialization, StateChange,

--- a/arcdps_codegen/src/export.rs
+++ b/arcdps_codegen/src/export.rs
@@ -61,7 +61,7 @@ impl ArcDpsGen {
             static __EXPORT: ::arcdps::callbacks::ArcDpsExport = ::arcdps::callbacks::ArcDpsExport {
                 size: ::std::mem::size_of::<::arcdps::callbacks::ArcDpsExport>(),
                 sig: #sig,
-                imgui_version: 18000,
+                imgui_version: ::arcdps::__macro::IMGUI_VERSION,
                 out_build: #build.as_ptr() as _,
                 out_name: #name_c.as_ptr() as _,
                 combat: #combat_value,


### PR DESCRIPTION
**Draft — not mergeable as-is.** It points the `imgui` dependency at a personal fork, because no published crate carries Dear ImGui 1.92.7 with the config arcdps needs. Opening it so the work is available and the constraints are written down; how to source the imgui crate is your call.

## Why

arcdps has linked Dear ImGui **1.92.7** since its 20260507 build and drops the UI callbacks of any plugin reporting a different `IMGUI_VERSION_NUM`. `arcdps-imgui` 0.8 is Dear ImGui 1.80, so every plugin built on these bindings currently loads and runs but never draws. `init_imgui` already skips setup on mismatch, which avoids the crash but not the blank UI.

## What is in here

- `arcdps/Cargo.toml`, `lib.rs` — depend on a fork of imgui-rs `main` vendoring 1.92.7 instead of `arcdps-imgui` 0.8.
- `globals/imgui.rs` — `IMGUI_VERSION` from the headers; context held in `ManuallyDrop` (dropping an `imgui::Context` destroys it); `Ui` lost its lifetime upstream, so `with_ui` borrows from the context instead of a `thread_local!`.
- Includes the one-liner from #17; I'll rebase once that lands.

Verified end to end: a plugin built on this branch loads under arcdps `20260811.193842-607-x64` and draws normally, `imgui version mismatch` gone.

## Constraints worth knowing if you take this on

The addon shares arcdps's `ImGuiContext`, so the vendored imgui must match arcdps's build byte for byte, not just by version number:

- **Release branch, not docking.** The arcdps API doc cites the v1.92.7 release tarball, and there are no docking symbols in the DLL. `cimgui` master tracks the docking branch, and so does `dear-imgui-rs` — both are ABI-incompatible here.
- **Stock `imconfig.h`.** No `IMGUI_USE_WCHAR32` (widens `ImWchar`) and **no `IMGUI_DISABLE_OBSOLETE_FUNCTIONS`** — the latter removes real struct members in 1.92 (`ImGuiIO::FontGlobalScale` sits mid-struct), so every field after it shifts. Same two reverts the old gw2scratch fork made for 1.80. This matches the vcpkg `imgui` port the working C++ addons link against.
- **cimgui's generator hardcodes `-DIMGUI_DISABLE_OBSOLETE_FUNCTIONS`** in `generator/generator.lua`, so it has to be stripped before generating, or the generated structs disagree with the compiled library.

The imgui-rs fork is at https://github.com/arnalon/imgui-rs/tree/arcdps-1.92.7 (Dear ImGui 1.92.7 vendored, cimgui + bindgen regenerated, high-level crate ported from 1.91.3). Upstream imgui-rs has an open issue for a 1.92 update — imgui-rs/imgui-rs#834 — so a properly published crate may eventually exist.
